### PR TITLE
Fixed Demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ this project was built with Next JS and tailwind CSS.
 
 ## Live Demo
 
-you can see the completed website in action [here](travel.apsyadira.com)
+you can see the completed website in action [here](//travel.apsyadira.com)
 
 ## Getting Started
 


### PR DESCRIPTION
When you click on the demo link in readme, it redirect to github.com/.../travel.apsyadira.com instead of navigating to //travel.apsyadira.com.